### PR TITLE
Use socks_socket package (submodule)

### DIFF
--- a/lib/src/fusion.dart
+++ b/lib/src/fusion.dart
@@ -372,12 +372,16 @@ class Fusion {
         );
         // In principle we can hook a pause in here -- user can tweak tier_outputs, perhaps cancelling some unwanted tiers.
 
+        Utilities.debugPrint("Registering for tiers, waiting for a pool...");
+
         // Register for tiers, wait for a pool.
         _registerAndWaitResult = await registerAndWait(
           socketWrapper: socketWrapper,
           connection: connection,
           allocatedOutputs: _allocatedOutputs!,
         );
+
+        Utilities.debugPrint("Starting covert submitter...");
 
         // launch the covert submitter
         final covert = await startCovert(
@@ -387,10 +391,15 @@ class Fusion {
           tFusionBegin: _tFusionBegin,
           serverParams: _serverParams!,
         );
+
+        _updateStatus(
+            status: FusionStatus.running, info: "Running fusion rounds.");
+
         try {
           // Pool started. Keep running rounds until fail or complete.
           while (true) {
             _roundCount += 1;
+            Utilities.debugPrint("Running round $_roundCount...");
             final success = await runRound(
               covert: covert,
               connection: connection,
@@ -1197,6 +1206,8 @@ class Fusion {
     /*
     final blindSigRequests = blindNoncePoints.map((e) => Schnorr.BlindSignatureRequest(roundPubKey, e, sha256(myComponents.elementAt(e)))).toList();
     */
+
+    Utilities.debugPrint("Generating blind signature requests.");
     List<BlindSignatureRequest> blindSigRequests =
         List.generate(blindNoncePoints.length, (index) {
       final R = blindNoncePoints[index];
@@ -1208,6 +1219,7 @@ class Fusion {
           R: Uint8List.fromList(R),
           messageHash: Uint8List.fromList(messageHash));
     });
+    Utilities.debugPrint("Generated blind signature requests.");
 
     /*
     Utilities.debugPrint("RETURNING EARLY FROM run round .....");
@@ -1219,6 +1231,9 @@ class Fusion {
     covert.checkOk();
     checkStop();
     checkCoins();
+    print(131313);
+
+    Utilities.debugPrint("Sending initial commitments etc.");
 
     // Send initial commitments, fees, and other data to the server.
     await IO.send(
@@ -1232,6 +1247,8 @@ class Fusion {
       socketWrapper: socketWrapper,
       connection: connection,
     );
+
+    Utilities.debugPrint("Awaiting signature responses from the server...");
 
     // Await blind signature responses from the server
     msg = await IO.recv([ReceiveMessages.blindSigResponses],
@@ -1262,6 +1279,8 @@ class Fusion {
         }
       },
     );
+
+    Utilities.debugPrint("Waiting for covert component submission phase...");
 
     // Sleep until the covert component phase really starts, to catch covert connection failures.
     double remainingTime = Protocol.T_START_COMPS - covertClock();

--- a/lib/src/fusion.dart
+++ b/lib/src/fusion.dart
@@ -1231,7 +1231,6 @@ class Fusion {
     covert.checkOk();
     checkStop();
     checkCoins();
-    print(131313);
 
     Utilities.debugPrint("Sending initial commitments etc.");
 

--- a/lib/src/models/blind_signature_request.dart
+++ b/lib/src/models/blind_signature_request.dart
@@ -6,7 +6,6 @@ import 'package:fusiondart/src/extensions/on_big_int.dart';
 import 'package:fusiondart/src/extensions/on_uint8list.dart';
 import 'package:fusiondart/src/util.dart';
 import 'package:pointycastle/ecc/api.dart';
-import 'package:pointycastle/ecc/curves/secp256r1.dart';
 
 /// A class representing a blind signature request.
 ///
@@ -68,8 +67,8 @@ class BlindSignatureRequest {
   /// Constructor: Initializes various fields and performs initial calculations.
   BlindSignatureRequest(
       {required this.pubkey, required this.R, required this.messageHash})
-      : order = ECCurve_secp256r1().n,
-        fieldsize = BigInt.from(ECCurve_secp256r1().curve.fieldSize) {
+      : order = Utilities.secp256k1Params.n,
+        fieldsize = BigInt.from(Utilities.secp256k1Params.curve.fieldSize) {
     // Check argument validity
     if (pubkey.length != 33 || R.length != 33 || messageHash.length != 32) {
       throw ArgumentError('Invalid argument lengths.');

--- a/lib/src/models/blind_signature_request.dart
+++ b/lib/src/models/blind_signature_request.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:fusiondart/src/extensions/on_big_int.dart';
-import 'package:fusiondart/src/extensions/on_uint8list.dart';
 import 'package:fusiondart/src/util.dart';
 import 'package:pointycastle/ecc/api.dart';
 
@@ -100,12 +99,19 @@ class BlindSignatureRequest {
   /// - A random BigInt value, up to [maxValue]
   BigInt _randomBigInt(BigInt maxValue) {
     final random = Random.secure();
-    final builder = BytesBuilder();
-    for (BigInt i = BigInt.zero; i < maxValue; i += BigInt.one) {
-      builder.addByte(random.nextInt(256));
-    }
-    final bytes = builder.toBytes();
-    return bytes.toBigInt;
+
+    // Calculate the number of bytes needed
+    int byteLength = (maxValue.bitLength + 7) ~/ 8;
+
+    BigInt result;
+    do {
+      final bytes = List<int>.generate(byteLength, (i) => random.nextInt(256));
+      result = BigInt.parse(
+          bytes.map((byte) => byte.toRadixString(16).padLeft(2, '0')).join(),
+          radix: 16);
+    } while (result >= maxValue);
+
+    return result;
   }
 
   /// Performs initial calculations needed for blind signature generation.


### PR DESCRIPTION
This adds the socks_socket package as a local submodule.  After (if) socks_socket is published, its usage via submodule can be replaced with a simple package import.

See https://github.com/cypherstack/fusiondart/blob/1eac63b49f1841aa78ebcc16e001029f5fab1dee/lib/src/connection.dart#L82-L90 , this may be overkill if the SocketWrapper included in fusiondart will suffice for our purposes.  Less dependencies is always better ... less maintenance etc